### PR TITLE
Make sensor support running from cpython

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+
+from distutils.core import setup
+
+setup(name='spikedev',
+      version='0.1',
+      description='Open source micropython library for LEGO SPIKE',
+      author='Daniel Walton',
+      author_email='dwalton76@gmail.com',
+      url='https://dwalton76.github.io/spikedev/',
+      packages=['spikedev'],
+      )

--- a/spikedev/logging.py
+++ b/spikedev/logging.py
@@ -1,5 +1,11 @@
 # standard libraries
-import utime
+try:
+    from utime import ticks_ms
+except ImportError:
+    from time import monotonic_ns
+
+    def ticks_ms():
+        return monotonic_ns() // 1000000
 
 
 def _timestamp():
@@ -15,7 +21,7 @@ def _timestamp():
     year = 2020
     month = 1
 
-    ms = utime.ticks_ms()
+    ms = ticks_ms()
     (day, ms) = divmod(ms, 86400000)
     (hour, ms) = divmod(ms, 3600000)
     (minute, ms) = divmod(ms, 60000)

--- a/spikedev/sensor.py
+++ b/spikedev/sensor.py
@@ -1,5 +1,8 @@
 # standard libraries
-import utime
+try:
+    from utime import sleep
+except ImportError:
+    from time import sleep
 
 # spikedev libraries
 from spikedev.logging import log_msg
@@ -21,7 +24,7 @@ class Sensor:
 
         # wait for sensor to connect
         while self.port.device is None:
-            utime.sleep(0.1)
+            sleep(0.1)
 
     def __str__(self):
         if self.desc is not None:
@@ -120,7 +123,7 @@ class TouchSensor(Sensor):
                 log_msg("{} was not pressed within {}ms".format(self, timeout_ms))
                 return False
 
-            utime.sleep(0.01)
+            sleep(0.01)
 
         log_msg("{} pressed".format(self))
         return True
@@ -144,7 +147,7 @@ class TouchSensor(Sensor):
                 log_msg("{} was not released within {}ms".format(self, timeout_ms))
                 return False
 
-            utime.sleep(0.01)
+            sleep(0.01)
 
         log_msg("{} released".format(self))
         return True

--- a/spikedev/stopwatch.py
+++ b/spikedev/stopwatch.py
@@ -29,7 +29,13 @@ A StopWatch class for tracking the amount of time between events
 """
 
 # standard libraries
-import utime
+try:
+    from utime import ticks_ms
+except ImportError:
+    from time import monotonic_ns
+
+    def ticks_ms():
+        return monotonic_ns() // 1000000
 
 
 class StopWatch(object):
@@ -58,7 +64,7 @@ class StopWatch(object):
             raise StopWatchAlreadyStartedException()
 
         self._stopped_total_time = None
-        self._start_time = utime.ticks_ms()
+        self._start_time = ticks_ms()
 
     def stop(self):
         """
@@ -67,7 +73,7 @@ class StopWatch(object):
         if self._start_time is None:
             return
 
-        self._stopped_total_time = utime.ticks_ms() - self._start_time
+        self._stopped_total_time = ticks_ms() - self._start_time
         self._start_time = None
 
     def reset(self):
@@ -100,7 +106,7 @@ class StopWatch(object):
         if self._stopped_total_time is not None:
             return self._stopped_total_time
 
-        return utime.ticks_ms() - self._start_time if self._start_time is not None else 0
+        return ticks_ms() - self._start_time if self._start_time is not None else 0
 
     @property
     def value_secs(self):


### PR DESCRIPTION
I made sensor.py support cpython, by using time.sleep() if utime.sleep() isn't available.

This allows me to use it from my computer connected to the hub, using https://github.com/noamraph/mindstorms

I also added setup.py, which allows me to `pip install` spikedev directly from github. It's unrelated, so if you prefer to remove it from the pull request I'll do it.